### PR TITLE
Update links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,7 @@ FBX files often have textures in a separate folder. Three ways to handle this:
 |--------|--------|-------|
 | [VRoid Hub](https://hub.vroid.com) | VRM | Free downloads, instant bone setup |
 | [VRoid Studio](https://vroid.com/en/studio) | VRM | Make your own avatar |
-| [Mixamo](https://mixamo.com) | FBX | Free auto-rigged characters |
-| [ReadyPlayer.Me](https://readyplayer.me) | GLB | Custom avatars |
+| [Mixamo](https://www.mixamo.com) | FBX | Free auto-rigged characters |
 | [Sketchfab](https://sketchfab.com) | GLB/FBX | Search for "rigged" models |
 
 ## Demo Model


### PR DESCRIPTION
- fixed mixamo url (mixamo has no apex domain route)
- removed ready player me link ("Ready Player Me services were discontinued on Jan 31, 2026")